### PR TITLE
fix: no mac_specific I found but this work well

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,14 +11,11 @@ from .pixelization.models import c2pGen
 
 import sys
 
-if sys.platform == "darwin":
-    import mac_specific
-
 def has_mps() -> bool:
     if sys.platform != "darwin":
         return False
     else:
-        return mac_specific.has_mps
+        return torch.backends.mps.is_available()
     
 def get_cuda_device_string():
     return "cuda"


### PR DESCRIPTION
I can't find mac_specific in pip, and I don't know what it is, but now I can run it normally on mac through this modification. I think there should be no problem. Torch itself has a function to check mps, so I hope This PR was accepted