### PR TITLE
Add a link for the civitai mirror for the required models

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ComfyUI node that pixelizes images
 
 1. Clone repository to `ComfyUI/custom_nodes/ComfyUI_pixelization`
 2. Go to folder
-3. Run `python ./install.py` 
+3. Run `python ./install.py`
 4. Download checkpoints to `ComfyUI/custom_nodes/ComfyUI_pixelization/checkpoints`
 5. Use node `Pixelization > Pixelization` to generate pixelated image
 
@@ -30,6 +30,7 @@ Download all three models from the table and place them into the `checkpoints` d
 | https://drive.google.com/file/d/17f2rKnZOpnO9ATwRXgqLz5u5AZsyDvq_/view?usp=sharing | alias_net.pth      |
 | https://drive.google.com/file/d/1i_8xL3stbLWNF4kdQJ50ZhnRFhSDh3Az/view?usp=sharing | 160_net_G_A.pth    |
 
+Alternatively, you can download the models from the [CivitAI mirror](https://civitai.com/models/1674670/make-your-own-sprites-models).
 
 # Credits
 


### PR DESCRIPTION
Made a mirror for the pixelization models on CivitAI, just in case the original links go down.

Linking this mirror in the README.